### PR TITLE
✨ Allow snake_case snapshot options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ browser = webdriver.Firefox()
 browser.get('http://example.com')
 ​
 # take a snapshot
-percy_snapshot(browser=browser, name='Python example')
+percy_snapshot(browser, 'Python example')
 ```
 
 Running the test above normally will result in the following log:
@@ -60,10 +60,10 @@ $ percy exec -- [python test command]
 - `name` (**required**) - The snapshot name; must be unique to each snapshot
 - Additional snapshot options (overrides any project options) (`**kwargs**`):
   - `widths` - An array of widths to take screenshots at
-  - `minHeight` - The minimum viewport height to take screenshots at
-  - `percyCSS` - Percy specific CSS only applied in Percy's rendering environment
-  - `requestHeaders` - Headers that should be used during asset discovery
-  - `enableJavaScript` - Enable JavaScript in Percy's rendering environment
+  - `min_height` - The minimum viewport height to take screenshots at
+  - `percy_css` - Percy specific CSS only applied in Percy's rendering environment
+  - `request_headers` - Headers that should be used during asset discovery
+  - `enable_javascript` - Enable JavaScript in Percy's rendering environment
 
 ### Migrating Config
 

--- a/percy/snapshot.py
+++ b/percy/snapshot.py
@@ -53,9 +53,9 @@ def percy_snapshot(driver, name, **kwargs):
 
         # Post the DOM to the snapshot endpoint with snapshot options and other info
         response = requests.post(f'{PERCY_CLI_API}/percy/snapshot', json=dict(**kwargs, **{
-            'domSnapshot': dom_snapshot,
-            'clientInfo': CLIENT_INFO,
-            'environmentInfo': ENV_INFO,
+            'client_info': CLIENT_INFO,
+            'environment_info': ENV_INFO,
+            'dom_snapshot': dom_snapshot,
             'url': driver.current_url,
             'name': name
         }))

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -4,8 +4,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Thread
 
 import httpretty
-from selenium import webdriver
-from selenium.webdriver.firefox.options import Options as FirefoxOptions
+from selenium.webdriver import Firefox, FirefoxOptions
 
 from percy import percy_snapshot
 import percy.snapshot as local
@@ -48,8 +47,8 @@ class TestPercySnapshot(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         options = FirefoxOptions()
-        options.add_argument('--headless')
-        cls.driver = webdriver.Firefox(options=options)
+        options.add_argument('-headless')
+        cls.driver = Firefox(options=options)
 
     @classmethod
     def tearDownClass(cls):
@@ -101,21 +100,21 @@ class TestPercySnapshot(unittest.TestCase):
         mock_snapshot()
 
         percy_snapshot(self.driver, 'Snapshot 1')
-        percy_snapshot(self.driver, 'Snapshot 2', enableJavaScript=True)
+        percy_snapshot(self.driver, 'Snapshot 2', enable_javascript=True)
 
         self.assertEqual(httpretty.last_request().path, '/percy/snapshot')
 
         s1 = httpretty.latest_requests()[2].parsed_body
         self.assertEqual(s1['name'], 'Snapshot 1')
         self.assertEqual(s1['url'], 'http://localhost:8000/')
-        self.assertEqual(s1['domSnapshot'], '<html><head></head><body>Snapshot Me</body></html>')
-        self.assertRegex(s1['clientInfo'], r'percy-selenium-python/\d+')
-        self.assertRegex(s1['environmentInfo'][0], r'selenium/\d+')
-        self.assertRegex(s1['environmentInfo'][1], r'python/\d+')
+        self.assertEqual(s1['dom_snapshot'], '<html><head></head><body>Snapshot Me</body></html>')
+        self.assertRegex(s1['client_info'], r'percy-selenium-python/\d+')
+        self.assertRegex(s1['environment_info'][0], r'selenium/\d+')
+        self.assertRegex(s1['environment_info'][1], r'python/\d+')
 
         s2 = httpretty.latest_requests()[3].parsed_body
         self.assertEqual(s2['name'], 'Snapshot 2')
-        self.assertEqual(s2['enableJavaScript'], True)
+        self.assertEqual(s2['enable_javascript'], True)
 
 
     def test_handles_snapshot_errors(self):


### PR DESCRIPTION
## What is this?

Percy CLI now accepts snake_case options which allows SDKs such as this one to adhere to language style conventions.

This is **not** a breaking change since this library still exports a camelCase variant and the CLI still accepts camelCase options.