### PR TITLE
🐛 Use functools.lru_cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,15 +3,18 @@ on: push
 jobs:
   test:
     name: Test
+    strategy:
+      matrix:
+        python: [3.6, 3.7, 3.8, 3.9]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.x
+          python-version: ${{ matrix.python }}
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: v1/${{ runner.os }}/pip/${{ hashFiles('{requirements,development}.txt') }}
-          restore-keys: v1/${{ runner.os }}/pip/
+          key: v1/${{ runner.os }}/pypi-${{matrix.python}}/${{ hashFiles('{requirements,development}.txt') }}
+          restore-keys: v1/${{ runner.os }}/pypi-${matrix.python}/
       - run: make test

--- a/percy/snapshot.py
+++ b/percy/snapshot.py
@@ -1,7 +1,7 @@
 import os
 import platform
-import functools
 import json
+from functools import lru_cache
 import requests
 
 from selenium.webdriver import __version__ as SELENIUM_VERSION
@@ -19,7 +19,7 @@ PERCY_DEBUG = os.environ.get('PERCY_LOGLEVEL') == 'debug'
 LABEL = '[\u001b[35m' + ('percy:python' if PERCY_DEBUG else 'percy') + '\u001b[39m]'
 
 # Check if Percy is enabled, caching the result so it is only checked once
-@functools.cache
+@lru_cache(maxsize=None)
 def is_percy_enabled():
     try:
         response = requests.get(f'{PERCY_CLI_API}/percy/healthcheck')
@@ -34,7 +34,7 @@ def is_percy_enabled():
         return False
 
 # Fetch the @percy/dom script, caching the result so it is only fetched once
-@functools.cache
+@lru_cache(maxsize=None)
 def fetch_percy_dom():
     response = requests.get(f'{PERCY_CLI_API}/percy/dom.js')
     response.raise_for_status()


### PR DESCRIPTION
## What is this

Fixes #13 

`functools.cache` is only available in Python 3.9

`functools.lru_cache` is available since Python 3.6

CI was updated to run tests in all Python versions