### PR TITLE
🐛 Fix backwards compatible function argument

### DIFF
--- a/percy/__init__.py
+++ b/percy/__init__.py
@@ -1,4 +1,6 @@
 from percy.snapshot import percy_snapshot
 from percy.version import __version__
+
 # for better backwards compatibility
-percySnapshot = percy_snapshot
+def percySnapshot(browser, *a, **kw):
+    return percy_snapshot(driver=browser, *a, **kw)

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -6,7 +6,7 @@ from threading import Thread
 import httpretty
 from selenium.webdriver import Firefox, FirefoxOptions
 
-from percy import percy_snapshot
+from percy import percy_snapshot, percySnapshot
 import percy.snapshot as local
 LABEL = local.LABEL
 
@@ -116,6 +116,18 @@ class TestPercySnapshot(unittest.TestCase):
         self.assertEqual(s2['name'], 'Snapshot 2')
         self.assertEqual(s2['enable_javascript'], True)
 
+    def test_has_a_backwards_compatible_function(self):
+        mock_healthcheck()
+        mock_snapshot()
+
+        percySnapshot(browser=self.driver, name='Snapshot')
+
+        self.assertEqual(httpretty.last_request().path, '/percy/snapshot')
+
+        s1 = httpretty.latest_requests()[2].parsed_body
+        self.assertEqual(s1['name'], 'Snapshot')
+        self.assertEqual(s1['url'], 'http://localhost:8000/')
+        self.assertEqual(s1['dom_snapshot'], '<html><head></head><body>Snapshot Me</body></html>')
 
     def test_handles_snapshot_errors(self):
         mock_healthcheck()


### PR DESCRIPTION
## What is this?

The old `percySnapshot` function had a `browser` argument, not a `driver` argument.

This PR fixes that with a signature transform as suggested by @kurtbrose.

Fixes #15 