### PR TITLE
🐛 Gate health check on CLI version

### DIFF
--- a/percy/snapshot.py
+++ b/percy/snapshot.py
@@ -27,6 +27,19 @@ def is_percy_enabled():
         data = response.json()
 
         if not data['success']: raise Exception(data['error'])
+        version = response.headers.get('x-percy-core-version')
+
+        if not version:
+            print(f'{LABEL} You may be using @percy/agent '
+                  'which is no longer supported by this SDK. '
+                  'Please uninstall @percy/agent and install @percy/cli instead. '
+                  'https://docs.percy.io/docs/migrating-to-percy-cli')
+            return False
+
+        if version.split('.')[0] != '1':
+            print(f'{LABEL} Unsupported Percy CLI version, {version}')
+            return False
+
         return True
     except Exception as e:
         print(f'{LABEL} Percy is not running, disabling snapshots')


### PR DESCRIPTION
## What is this?

If this SDK is used with `@percy/agent`, it will pass the health check but fail to download the DOM serialization script. This can be caught by checking for the presence of the `X-Percy-Core-Version` header. We can also check the version to ensure future compatibility with major CLI versions as well.

This change makes it so the health check will now fail if the header is incorrect. When it is missing, `@percy/agent` is likely installed; so a message is logged instructing the user how to take further action.