### PR TITLE
🧹 Fix stale issue label

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,3 +28,4 @@ jobs:
           exempt-issue-labels: '🐛 bug,❄️ on ice,✨ enhancement'
           exempt-all-assignees: true
           stale-pr-label: '🍞 stale'
+          stale-issue-label: '🍞 stale'


### PR DESCRIPTION
## What is this?

Forgot to add `stale-issue-label` to the config 🤦🏻‍♂️ (all of the repos added a generic "Stale" label 🤢 )

## Question

Should this PR add dependabot to this rep?