### PR TITLE
🐛 Loosen selenium dependency requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=['percy'],
     include_package_data=True,
     install_requires=[
-        'selenium==3.*',
+        'selenium>=3',
         'requests==2.*'
     ],
     python_requires='>=3.6',


### PR DESCRIPTION
## What is this?

This SDK was built before selenium 4 was stable. This PR will loosen the requirement so the SDK will work with any version of selenium (which it will).