### PR TITLE
Updated module loader to support both packages

### DIFF
--- a/percy/__init__.py
+++ b/percy/__init__.py
@@ -1,6 +1,20 @@
-from percy.snapshot import percy_snapshot
 from percy.version import __version__
 
+# import snapshot command
+try:
+  from percy.snapshot import percy_snapshot
+except:
+  def percy_snapshot(driver, *a, **kw):
+    raise Exception("[percy] `percy-selenium` package is not installed, please install it to use percy_snapshot command")
+  
 # for better backwards compatibility
 def percySnapshot(browser, *a, **kw):
-    return percy_snapshot(driver=browser, *a, **kw)
+  return percy_snapshot(driver=browser, *a, **kw)
+
+# improt screenshot command
+try:
+  from percy.screenshot import percy_screenshot
+except:
+  def percy_screenshot(driver, *a, **kw):
+    raise Exception("[percy] `percy-appium-app` package is not installed, please install it to use percy_screenshot command")
+

--- a/percy/__init__.py
+++ b/percy/__init__.py
@@ -2,19 +2,20 @@ from percy.version import __version__
 
 # import snapshot command
 try:
-  from percy.snapshot import percy_snapshot
-except:
-  def percy_snapshot(driver, *a, **kw):
-    raise Exception("[percy] `percy-selenium` package is not installed, please install it to use percy_snapshot command")
-  
+    from percy.snapshot import percy_snapshot
+except ImportError:
+    def percy_snapshot(driver, *a, **kw):
+        raise ModuleNotFoundError("[percy] `percy-selenium` package is not installed, "\
+                        "please install it to use percy_snapshot command")
+
 # for better backwards compatibility
 def percySnapshot(browser, *a, **kw):
-  return percy_snapshot(driver=browser, *a, **kw)
+    return percy_snapshot(driver=browser, *a, **kw)
 
-# improt screenshot command
+# import screenshot command
 try:
-  from percy.screenshot import percy_screenshot
-except:
-  def percy_screenshot(driver, *a, **kw):
-    raise Exception("[percy] `percy-appium-app` package is not installed, please install it to use percy_screenshot command")
-
+    from percy.screenshot import percy_screenshot
+except ImportError:
+    def percy_screenshot(driver, *a, **kw):
+        raise ModuleNotFoundError("[percy] `percy-appium-app` package is not installed, "\
+                        "please install it to use percy_screenshot command")


### PR DESCRIPTION
- Now we support `percy-selenium` and `percy-appium-app` in same python environment
- By importing both packages in both __init__ files, even though one overrides other while installation, either can be used to execute both commands as long as packages are installed

Linked PR: https://github.com/percy/percy-appium-python/pull/32