### PR TITLE
Options Fix and Increase Timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,15 @@ jobs:
     runs-on: ${{ matrix.python == 3.6 && 'ubuntu-20.04' || 'ubuntu-latest' }}
 
     steps:
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: regex-match
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          text: ${{ github.event.inputs.branch }}
+          regex: '^[a-zA-Z0-9_/\-]+$'
+      - name: Break on invalid branch name
+        run: exit 1
+        if: ${{ github.event_name == 'workflow_dispatch' && steps.regex-match.outputs && steps.regex-match.outputs.match == '' }}
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:

--- a/percy/snapshot.py
+++ b/percy/snapshot.py
@@ -83,7 +83,7 @@ def percy_snapshot(driver, name, **kwargs):
         print(f'{LABEL} {e}')
 
 # Take screenshot on driver
-def percy_automate_screenshot(driver, name, options = dict(), **kwargs):
+def percy_automate_screenshot(driver, name, options = {}, **kwargs):
     if not is_percy_enabled(): return
 
     try:

--- a/percy/snapshot.py
+++ b/percy/snapshot.py
@@ -83,8 +83,10 @@ def percy_snapshot(driver, name, **kwargs):
         print(f'{LABEL} {e}')
 
 # Take screenshot on driver
-def percy_automate_screenshot(driver, name, options = {}, **kwargs):
+def percy_automate_screenshot(driver, name, options = None, **kwargs):
     if not is_percy_enabled(): return
+    if options is None:
+        options = {}
 
     try:
         ignore_region_elements = get_element_ids(

--- a/percy/snapshot.py
+++ b/percy/snapshot.py
@@ -83,17 +83,18 @@ def percy_snapshot(driver, name, **kwargs):
         print(f'{LABEL} {e}')
 
 # Take screenshot on driver
-def percy_automate_screenshot(driver, name, **kwargs):
+def percy_automate_screenshot(driver, name, options = dict(), **kwargs):
     if not is_percy_enabled(): return
 
     try:
         ignore_region_elements = get_element_ids(
-            kwargs.get("ignore_region_selenium_elements", [])
+            options.get("ignore_region_selenium_elements", [])
         )
-        kwargs.pop("ignore_region_selenium_elements", None)
+        options.pop("ignore_region_selenium_elements", None)
+        options["ignore_region_elements"] = ignore_region_elements
 
         # Post to automateScreenshot endpoint with driver options and other info
-        response = requests.post(f'{PERCY_CLI_API}/percy/automateScreenshot', json={
+        response = requests.post(f'{PERCY_CLI_API}/percy/automateScreenshot', json={**kwargs, **{
             'client_info': CLIENT_INFO,
             'environment_info': ENV_INFO,
             'sessionId': driver.session_id,
@@ -101,8 +102,8 @@ def percy_automate_screenshot(driver, name, **kwargs):
             'capabilities': dict(driver.capabilities),
             'sessionCapabilites':dict(driver.desired_capabilities),
             'snapshotName': name,
-            'options': { **kwargs, "ignore_region_elements": ignore_region_elements }
-        }, timeout=30)
+            'options': options
+        }}, timeout=60)
 
         # Handle errors
         response.raise_for_status()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -268,8 +268,8 @@ class TestPercyScreenshot(unittest.TestCase):
         element = Mock(spec=WebElement)
         element.id = 'Dummy_id'
         percy_screenshot(self.driver, 'Snapshot 1')
-        percy_screenshot(self.driver, 'Snapshot 2', enable_javascript=True,
-                          ignore_region_selenium_elements= [element])
+        percy_screenshot(self.driver, 'Snapshot 2', options = { "enable_javascript": True,
+                          "ignore_region_selenium_elements": [element]})
 
         self.assertEqual(httpretty.last_request().path, '/percy/automateScreenshot')
 


### PR DESCRIPTION
Standardising the way of passing options in python.
The `**kwargs` was wrapping the options however CLI for PoA expects things inside a hash of `options`.
Increasing timeout to 60secs, have observed timeouts sometimes.