### PR TITLE
Added support for responsive snapshot capture

### DIFF
--- a/percy/snapshot.py
+++ b/percy/snapshot.py
@@ -27,8 +27,8 @@ def log(message, lvl = 'info'):
     try:
         requests.post(f'{PERCY_CLI_API}/percy/log',
                     json={'message': message, 'level': lvl}, timeout=1)
-    except:
-        if PERCY_DEBUG: print('Sending log to CLI Failed')
+    except Exception as e:
+        if PERCY_DEBUG: print(f'Sending log to CLI Failed {e}')
     finally:
         print(message)
 

--- a/percy/snapshot.py
+++ b/percy/snapshot.py
@@ -140,6 +140,9 @@ def capture_responsive_dom(driver, eligible_widths, cookies, **kwargs):
     return dom_snapshots
 
 def is_responsive_snapshot_capture(config, **kwargs):
+    # Don't run resposive snapshot capture when defer uploads is enabled
+    if 'percy' in config and config['percy'].get('deferUploads', False): return False
+
     return kwargs.get('responsive_snapshot_capture', False) or kwargs.get(
             'responsiveSnapshotCapture', False) or (
                 'snapshot' in config and config['snapshot'].get('responsiveSnapshotCapture'))

--- a/percy/snapshot.py
+++ b/percy/snapshot.py
@@ -27,6 +27,7 @@ CDP_SUPPORT_SELENIUM = (str(SELENIUM_VERSION)[0].isdigit() and int(
 eligible_widths = {}
 
 def log(message, lvl = 'info'):
+    message = f'{LABEL} {message}'
     try:
         requests.post(f'{PERCY_CLI_API}/percy/log',
                     json={'message': message, 'level': lvl}, timeout=1)
@@ -186,8 +187,8 @@ def percy_snapshot(driver, name, **kwargs):
         if not data['success']: raise Exception(data['error'])
         return data.get("data", None)
     except Exception as e:
-        log(f'{LABEL} Could not take DOM snapshot "{name}"')
-        log(f'{LABEL} {e}')
+        log(f'Could not take DOM snapshot "{name}"')
+        log(f'{e}')
         return None
 
 # Take screenshot on driver
@@ -243,8 +244,8 @@ def percy_automate_screenshot(driver, name, options = None, **kwargs):
         if not data['success']: raise Exception(data['error'])
         return data.get("data", None)
     except Exception as e:
-        log(f'{LABEL} Could not take Screenshot "{name}"')
-        log(f'{LABEL} {e}')
+        log(f'Could not take Screenshot "{name}"')
+        log(f'{e}')
         return None
 
 def get_element_ids(elements):

--- a/percy/snapshot.py
+++ b/percy/snapshot.py
@@ -33,9 +33,9 @@ def log(message, lvl = 'info'):
     except Exception as e:
         if PERCY_DEBUG: print(f'Sending log to CLI Failed {e}')
     finally:
-        # Do not log on console if percy_debug is not true
-        if lvl == 'debug' and not PERCY_DEBUG: return
-        print(message)
+        # Only log if lvl is 'debug' and PERCY_DEBUG is True
+        if lvl != 'debug' or PERCY_DEBUG:
+            print(message)
 
 # Check if Percy is enabled, caching the result so it is only checked once
 @lru_cache(maxsize=None)
@@ -101,8 +101,8 @@ def change_window_dimension_and_wait(driver, width, height, resizeCount):
                                 'width': width, 'deviceScaleFactor': 1, 'mobile': False })
         else:
             driver.set_window_size(width, height)
-    except:
-        log(f'Resizing using cdp failed falling back driver for width {width}', 'debug')
+    except Exception as e:
+        log(f'Resizing using cdp failed falling back driver for width {width} {e}', 'debug')
         driver.set_window_size(width, height)
 
     try:

--- a/percy/snapshot.py
+++ b/percy/snapshot.py
@@ -2,12 +2,12 @@ import os
 import platform
 import json
 from functools import lru_cache
+from time import sleep
 import requests
 
 from selenium.webdriver import __version__ as SELENIUM_VERSION
 from percy.version import __version__ as SDK_VERSION
 from percy.driver_metadata import DriverMetaData
-from time import sleep
 
 # Collect client and environment information
 CLIENT_INFO = 'percy-selenium-python/' + SDK_VERSION
@@ -19,11 +19,13 @@ PERCY_DEBUG = os.environ.get('PERCY_LOGLEVEL') == 'debug'
 
 # for logging
 LABEL = '[\u001b[35m' + ('percy:python' if PERCY_DEBUG else 'percy') + '\u001b[39m]'
-CDP_SUPPORT_SELENIUM = (str(SELENIUM_VERSION)[0].isdigit() and int(str(SELENIUM_VERSION)[0]) >= 4) if SELENIUM_VERSION else False
+CDP_SUPPORT_SELENIUM = (str(SELENIUM_VERSION)[0].isdigit() and int(
+    str(SELENIUM_VERSION)[0]) >= 4) if SELENIUM_VERSION else False
 fetched_widths = {}
 
 def log(message, lvl = 'info'):
-    requests.post(f'{PERCY_CLI_API}/percy/log', json={ 'message': message, 'level': lvl }, timeout=30)
+    requests.post(f'{PERCY_CLI_API}/percy/log',
+                  json={'message': message, 'level': lvl}, timeout=30)
     print(message)
 
 # Check if Percy is enabled, caching the result so it is only checked once
@@ -66,7 +68,6 @@ def fetch_percy_dom():
 
 @lru_cache(maxsize=None)
 def get_widths_for_multi_dom(widths):
-    global fetched_widths
     # Deep copy mobile widths otherwise it will get overridden
     allWidths = fetched_widths.get('mobile', [])[:]
     if widths and len(widths) != 0:
@@ -77,7 +78,8 @@ def get_widths_for_multi_dom(widths):
 
 def change_window_dimension(driver, width, height):
     if CDP_SUPPORT_SELENIUM and driver.capabilities['browserName'] == 'chrome':
-        driver.execute_cdp_cmd('Emulation.setDeviceMetricsOverride', { 'height': height, 'width': width, 'deviceScaleFactor': 1, 'mobile': False })
+        driver.execute_cdp_cmd('Emulation.setDeviceMetricsOverride', { 'height': height,
+                               'width': width, 'deviceScaleFactor': 1, 'mobile': False })
     else:
         driver.set_window_size(width, height)
 
@@ -112,7 +114,6 @@ def percy_snapshot(driver, name, **kwargs):
       "For more information on usage of PercyScreenshot, "\
       "refer https://www.browserstack.com/docs/percy/integrate/functional-and-visual")
 
-
     try:
         # Inject the DOM serialization script
         driver.execute_script(fetch_percy_dom())
@@ -120,7 +121,8 @@ def percy_snapshot(driver, name, **kwargs):
         user_agent = driver.execute_script("return navigator.userAgent;")
 
         # Serialize and capture the DOM
-        if kwargs.get('responsive_snapshot_capture', False) or kwargs.get('responsiveSnapshotCapture', False):
+        if kwargs.get('responsive_snapshot_capture', False) or kwargs.get(
+            'responsiveSnapshotCapture', False):
             dom_snapshot = capture_responsive_dom(driver, cookies, **kwargs)
         else:
             dom_snapshot = driver.execute_script(f'return PercyDOM.serialize({json.dumps(kwargs)})')

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -6,7 +6,7 @@ import json
 
 import httpretty
 import requests
-from selenium.webdriver import Firefox, FirefoxOptions
+from selenium.webdriver import Firefox, FirefoxOptions, Chrome
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.remote.remote_connection import RemoteConnection
@@ -48,7 +48,7 @@ data_object = {"sync": "true", "diff": 0}
 
 
 # mock helpers
-def mock_healthcheck(fail=False, fail_how='error', session_type=None):
+def mock_healthcheck(fail=False, fail_how='error', session_type=None, widths = {}):
     health_body = { "success": True }
     health_headers = { 'X-Percy-Core-Version': '1.0.0' }
     health_status = 200
@@ -64,6 +64,7 @@ def mock_healthcheck(fail=False, fail_how='error', session_type=None):
     if session_type:
         health_body["type"] = session_type
 
+    health_body['widths'] = widths
     health_body = json.dumps(health_body)
     httpretty.register_uri(
         httpretty.GET, 'http://localhost:5338/percy/healthcheck',
@@ -72,7 +73,7 @@ def mock_healthcheck(fail=False, fail_how='error', session_type=None):
         status=health_status)
     httpretty.register_uri(
         httpretty.GET, 'http://localhost:5338/percy/dom.js',
-        body='window.PercyDOM = { serialize: () => document.documentElement.outerHTML };',
+        body='window.PercyDOM = { serialize: () => { return { html: document.documentElement.outerHTML } } };',
         status=200)
 
 def mock_snapshot(fail=False, data=False):
@@ -84,6 +85,13 @@ def mock_snapshot(fail=False, data=False):
             "data": data_object if data else None
         }),
         status=(500 if fail else 200))
+
+def mock_logger():
+    httpretty.register_uri(
+        httpretty.POST, 'http://localhost:5338/percy/log',
+        body = json.dumps({ "success": "true" }),
+        status=200
+    )
 
 def mock_screenshot(fail=False, data=False):
 
@@ -112,6 +120,7 @@ class TestPercySnapshot(unittest.TestCase):
         local.is_percy_enabled.cache_clear()
         local.fetch_percy_dom.cache_clear()
         self.driver.get('http://localhost:8000')
+        self.driver.delete_all_cookies()
         httpretty.enable()
 
     def tearDown(self):
@@ -165,6 +174,8 @@ class TestPercySnapshot(unittest.TestCase):
     def test_posts_snapshots_to_the_local_percy_server(self):
         mock_healthcheck()
         mock_snapshot()
+        self.driver.add_cookie({'name': 'foo', 'value': 'bar'})
+        expected_cookies = [{'name': 'foo', 'value': 'bar', 'path': '/', 'domain': 'localhost', 'secure': False, 'httpOnly': False, 'sameSite': 'None'}]
 
         percy_snapshot(self.driver, 'Snapshot 1')
         response = percy_snapshot(self.driver, 'Snapshot 2', enable_javascript=True)
@@ -174,10 +185,11 @@ class TestPercySnapshot(unittest.TestCase):
         s1 = httpretty.latest_requests()[2].parsed_body
         self.assertEqual(s1['name'], 'Snapshot 1')
         self.assertEqual(s1['url'], 'http://localhost:8000/')
-        self.assertEqual(s1['dom_snapshot'], '<html><head></head><body>Snapshot Me</body></html>')
+        self.assertEqual(s1['dom_snapshot'], { 'cookies': expected_cookies, 'html': '<html><head></head><body>Snapshot Me</body></html>'})
         self.assertRegex(s1['client_info'], r'percy-selenium-python/\d+')
         self.assertRegex(s1['environment_info'][0], r'selenium/\d+')
         self.assertRegex(s1['environment_info'][1], r'python/\d+')
+        self.assertRegex(s1['environment_info'][2], r'Mozilla/\d+')
 
         s2 = httpretty.latest_requests()[3].parsed_body
         self.assertEqual(s2['name'], 'Snapshot 2')
@@ -196,7 +208,7 @@ class TestPercySnapshot(unittest.TestCase):
         s1 = httpretty.latest_requests()[2].parsed_body
         self.assertEqual(s1['name'], 'Snapshot 1')
         self.assertEqual(s1['url'], 'http://localhost:8000/')
-        self.assertEqual(s1['dom_snapshot'], '<html><head></head><body>Snapshot Me</body></html>')
+        self.assertEqual(s1['dom_snapshot'], { 'html': '<html><head></head><body>Snapshot Me</body></html>', 'cookies': [] })
         self.assertRegex(s1['client_info'], r'percy-selenium-python/\d+')
         self.assertRegex(s1['environment_info'][0], r'selenium/\d+')
         self.assertRegex(s1['environment_info'][1], r'python/\d+')
@@ -206,6 +218,59 @@ class TestPercySnapshot(unittest.TestCase):
         self.assertEqual(s2['enable_javascript'], True)
         self.assertEqual(s2['sync'], True)
         self.assertEqual(response, data_object)
+    
+    def test_posts_snapshots_to_the_local_percy_server_for_responsive_snapshot_capture(self):
+        mock_healthcheck(widths = { "config": [375, 1280], "mobile": [390]})
+        mock_snapshot()
+        dom_string = '<html><head></head><body>Snapshot Me</body></html>'
+        self.driver.add_cookie({'name': 'foo', 'value': 'bar'})
+        expected_cookies = [{'name': 'foo', 'value': 'bar', 'path': '/', 'domain': 'localhost', 'secure': False, 'httpOnly': False, 'sameSite': 'None'}]
+        expected_dom_snapshot = [{ 'cookies': expected_cookies, 'html': dom_string, 'width': 1280 }, { 'cookies': expected_cookies, 'html': dom_string, 'width': 390 }, { 'cookies': expected_cookies, 'html': dom_string, 'width': 375 }]
+
+        percy_snapshot(self.driver, 'Snapshot 1', responsiveSnapshotCapture = True)
+        percy_snapshot(self.driver, 'Snapshot 2', responsive_snapshot_capture = True, widths = [765])
+        percy_snapshot(self.driver, 'Snapshot 3', responsive_snapshot_capture = True, width = 820)
+
+        self.assertEqual(httpretty.last_request().path, '/percy/snapshot')
+
+        s1 = httpretty.latest_requests()[2].parsed_body
+        self.assertEqual(s1['name'], 'Snapshot 1')
+        self.assertEqual(s1['url'], 'http://localhost:8000/')
+        self.assertEqual(s1['dom_snapshot'], expected_dom_snapshot)
+        self.assertRegex(s1['client_info'], r'percy-selenium-python/\d+')
+        self.assertRegex(s1['environment_info'][0], r'selenium/\d+')
+        self.assertRegex(s1['environment_info'][1], r'python/\d+')
+
+        s2 = httpretty.latest_requests()[3].parsed_body
+        self.assertEqual(s2['name'], 'Snapshot 2')
+        self.assertEqual(s2['dom_snapshot'], [{ 'cookies': expected_cookies, 'html': dom_string, 'width': 765 }, { 'html': dom_string, 'cookies': expected_cookies, 'width': 390 }])
+
+        s3 = httpretty.latest_requests()[4].parsed_body
+        self.assertEqual(s3['name'], 'Snapshot 3')
+        self.assertEqual(s3['dom_snapshot'], [{ 'cookies': expected_cookies, 'html': dom_string, 'width': 820 }, { 'html': dom_string, 'cookies': expected_cookies, 'width': 390 }])
+
+    @patch('selenium.webdriver.Chrome')
+    def test_posts_snapshots_to_the_local_percy_server_for_responsive_snapshot_capture_with_cdp(self, MockChrome):
+        driver = MockChrome.return_value
+        driver.execute_script.side_effect = ['', '', { 'html': 'some_dom' }, { 'html': 'some_dom_1' }]
+        driver.get_cookies.return_value = ''
+        driver.execute_cdp_cmd.return_value = ''
+        driver.get_window_size.return_value = { 'height': 400, 'width': 800 }
+        mock_healthcheck(widths = { "config": [375], "mobile": [390]})
+        mock_snapshot()
+        expected_dom_snapshot = [{ 'cookies': '', 'html': 'some_dom', 'width': 600 }, { 'cookies': '', 'html': 'some_dom_1', 'width': 390 }]
+
+        with patch.object(driver, 'current_url', 'http://localhost:8000/'):
+            with patch.object(driver, 'capabilities', new={ 'browserName': 'chrome' }):
+                percy_snapshot(driver, 'Snapshot 1', responsiveSnapshotCapture = True, width = 600)
+
+        self.assertEqual(httpretty.last_request().path, '/percy/snapshot')
+
+        s1 = httpretty.latest_requests()[2].parsed_body
+        self.assertEqual(s1['name'], 'Snapshot 1')
+        self.assertEqual(s1['url'], 'http://localhost:8000/')
+        self.assertEqual(s1['dom_snapshot'], expected_dom_snapshot)
+
 
     def test_has_a_backwards_compatible_function(self):
         mock_healthcheck()
@@ -218,16 +283,19 @@ class TestPercySnapshot(unittest.TestCase):
         s1 = httpretty.latest_requests()[2].parsed_body
         self.assertEqual(s1['name'], 'Snapshot')
         self.assertEqual(s1['url'], 'http://localhost:8000/')
-        self.assertEqual(s1['dom_snapshot'], '<html><head></head><body>Snapshot Me</body></html>')
+        self.assertEqual(s1['dom_snapshot'], { 'html': '<html><head></head><body>Snapshot Me</body></html>', 'cookies': [] })
 
     def test_handles_snapshot_errors(self):
         mock_healthcheck(session_type="web")
         mock_snapshot(fail=True)
+        mock_logger()
 
         with patch('builtins.print') as mock_print:
             percy_snapshot(self.driver, 'Snapshot 1')
 
             mock_print.assert_any_call(f'{LABEL} Could not take DOM snapshot "Snapshot 1"')
+        self.assertEqual(httpretty.latest_requests()[3].parsed_body, { 'message': f'{LABEL} Could not take DOM snapshot "Snapshot 1"', 'level': 'info' })
+        self.assertEqual(len(httpretty.latest_requests()), 5)
 
     def test_raise_error_poa_token_with_snapshot(self):
         mock_healthcheck(session_type="automate")
@@ -387,11 +455,14 @@ class TestPercyScreenshot(unittest.TestCase):
     def test_handles_screenshot_errors(self):
         mock_healthcheck(session_type="automate")
         mock_screenshot(fail=True)
+        mock_logger()
 
         with patch('builtins.print') as mock_print:
             percy_screenshot(self.driver, 'Snapshot 1')
 
             mock_print.assert_any_call(f'{LABEL} Could not take Screenshot "Snapshot 1"')
+        
+        self.assertEqual(httpretty.latest_requests()[2].parsed_body, { 'message': f'{LABEL} Could not take Screenshot "Snapshot 1"', 'level': 'info' })
 
     def test_raise_error_web_token_with_screenshot(self):
         mock_healthcheck(session_type="web")

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -75,7 +75,9 @@ def mock_healthcheck(fail=False, fail_how='error', session_type=None, widths = N
     httpretty.register_uri(
         httpretty.GET, 'http://localhost:5338/percy/dom.js',
         body='window.PercyDOM = \
-         { serialize: () => { return { html: document.documentElement.outerHTML } } };',
+         { serialize: () => { return { html: document.documentElement.outerHTML } }, \
+           waitForResize: () => { if(!window.resizeCount) { window.addEventListener(\'resize\',\
+             () => window.resizeCount++) } window.resizeCount = 0; }}',
         status=200)
 
 def mock_snapshot(fail=False, data=False):

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -275,7 +275,8 @@ class TestPercySnapshot(unittest.TestCase):
 
     def test_posts_snapshots_to_the_local_percy_server_with_defer_and_responsive(self):
         mock_logger()
-        mock_healthcheck(widths = { "config": [375, 1280], "mobile": [390]}, config = { 'percy': { 'deferUploads': True }})
+        mock_healthcheck(widths = { "config": [375, 1280], "mobile": [390]},
+                         config = { 'percy': { 'deferUploads': True }})
         mock_snapshot()
         dom_string = '<html><head></head><body>Snapshot Me</body></html>'
         expected_dom_snapshot = { 'html': dom_string, 'cookies': [] }

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -192,7 +192,6 @@ class TestPercySnapshot(unittest.TestCase):
         self.assertRegex(s1['client_info'], r'percy-selenium-python/\d+')
         self.assertRegex(s1['environment_info'][0], r'selenium/\d+')
         self.assertRegex(s1['environment_info'][1], r'python/\d+')
-        self.assertRegex(s1['environment_info'][2], r'Mozilla/\d+')
 
         s2 = httpretty.latest_requests()[3].parsed_body
         self.assertEqual(s2['name'], 'Snapshot 2')
@@ -268,7 +267,7 @@ class TestPercySnapshot(unittest.TestCase):
     def test_posts_snapshots_to_the_local_percy_server_for_responsive_dom_chrome(self, MockChrome):
         driver = MockChrome.return_value
         driver.execute_script.side_effect = [
-            '', '', { 'html': 'some_dom' }, { 'html': 'some_dom_1' }
+            '', { 'html': 'some_dom' }, { 'html': 'some_dom_1' }
         ]
         driver.get_cookies.return_value = ''
         driver.execute_cdp_cmd.return_value = ''

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from unittest.mock import patch, Mock
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -265,9 +266,10 @@ class TestPercySnapshot(unittest.TestCase):
 
     @patch('selenium.webdriver.Chrome')
     def test_posts_snapshots_to_the_local_percy_server_for_responsive_dom_chrome(self, MockChrome):
+        os.environ['RESONSIVE_CAPTURE_SLEEP_TIME'] = '1'
         driver = MockChrome.return_value
         driver.execute_script.side_effect = [
-            '', { 'html': 'some_dom' }, { 'html': 'some_dom_1' }
+            '', '', 1, { 'html': 'some_dom' }, 2, { 'html': 'some_dom_1' }, 3
         ]
         driver.get_cookies.return_value = ''
         driver.execute_cdp_cmd.return_value = ''
@@ -289,7 +291,6 @@ class TestPercySnapshot(unittest.TestCase):
         self.assertEqual(s1['name'], 'Snapshot 1')
         self.assertEqual(s1['url'], 'http://localhost:8000/')
         self.assertEqual(s1['dom_snapshot'], expected_dom_snapshot)
-
 
     def test_has_a_backwards_compatible_function(self):
         mock_healthcheck()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -6,7 +6,7 @@ import json
 
 import httpretty
 import requests
-from selenium.webdriver import Firefox, FirefoxOptions, Chrome
+from selenium.webdriver import Firefox, FirefoxOptions
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.remote.remote_connection import RemoteConnection
@@ -48,7 +48,7 @@ data_object = {"sync": "true", "diff": 0}
 
 
 # mock helpers
-def mock_healthcheck(fail=False, fail_how='error', session_type=None, widths = {}):
+def mock_healthcheck(fail=False, fail_how='error', session_type=None, widths = None):
     health_body = { "success": True }
     health_headers = { 'X-Percy-Core-Version': '1.0.0' }
     health_status = 200
@@ -64,7 +64,7 @@ def mock_healthcheck(fail=False, fail_how='error', session_type=None, widths = {
     if session_type:
         health_body["type"] = session_type
 
-    health_body['widths'] = widths
+    if widths: health_body['widths'] = widths
     health_body = json.dumps(health_body)
     httpretty.register_uri(
         httpretty.GET, 'http://localhost:5338/percy/healthcheck',
@@ -73,7 +73,8 @@ def mock_healthcheck(fail=False, fail_how='error', session_type=None, widths = {
         status=health_status)
     httpretty.register_uri(
         httpretty.GET, 'http://localhost:5338/percy/dom.js',
-        body='window.PercyDOM = { serialize: () => { return { html: document.documentElement.outerHTML } } };',
+        body='window.PercyDOM = \
+         { serialize: () => { return { html: document.documentElement.outerHTML } } };',
         status=200)
 
 def mock_snapshot(fail=False, data=False):
@@ -175,7 +176,8 @@ class TestPercySnapshot(unittest.TestCase):
         mock_healthcheck()
         mock_snapshot()
         self.driver.add_cookie({'name': 'foo', 'value': 'bar'})
-        expected_cookies = [{'name': 'foo', 'value': 'bar', 'path': '/', 'domain': 'localhost', 'secure': False, 'httpOnly': False, 'sameSite': 'None'}]
+        expected_cookies = [{'name': 'foo', 'value': 'bar', 'path': '/',
+            'domain': 'localhost', 'secure': False, 'httpOnly': False, 'sameSite': 'None'}]
 
         percy_snapshot(self.driver, 'Snapshot 1')
         response = percy_snapshot(self.driver, 'Snapshot 2', enable_javascript=True)
@@ -185,7 +187,8 @@ class TestPercySnapshot(unittest.TestCase):
         s1 = httpretty.latest_requests()[2].parsed_body
         self.assertEqual(s1['name'], 'Snapshot 1')
         self.assertEqual(s1['url'], 'http://localhost:8000/')
-        self.assertEqual(s1['dom_snapshot'], { 'cookies': expected_cookies, 'html': '<html><head></head><body>Snapshot Me</body></html>'})
+        self.assertEqual(s1['dom_snapshot'], { 'cookies': expected_cookies,
+            'html': '<html><head></head><body>Snapshot Me</body></html>'})
         self.assertRegex(s1['client_info'], r'percy-selenium-python/\d+')
         self.assertRegex(s1['environment_info'][0], r'selenium/\d+')
         self.assertRegex(s1['environment_info'][1], r'python/\d+')
@@ -208,7 +211,8 @@ class TestPercySnapshot(unittest.TestCase):
         s1 = httpretty.latest_requests()[2].parsed_body
         self.assertEqual(s1['name'], 'Snapshot 1')
         self.assertEqual(s1['url'], 'http://localhost:8000/')
-        self.assertEqual(s1['dom_snapshot'], { 'html': '<html><head></head><body>Snapshot Me</body></html>', 'cookies': [] })
+        self.assertEqual(s1['dom_snapshot'], {
+            'html': '<html><head></head><body>Snapshot Me</body></html>', 'cookies': [] })
         self.assertRegex(s1['client_info'], r'percy-selenium-python/\d+')
         self.assertRegex(s1['environment_info'][0], r'selenium/\d+')
         self.assertRegex(s1['environment_info'][1], r'python/\d+')
@@ -218,17 +222,22 @@ class TestPercySnapshot(unittest.TestCase):
         self.assertEqual(s2['enable_javascript'], True)
         self.assertEqual(s2['sync'], True)
         self.assertEqual(response, data_object)
-    
+
     def test_posts_snapshots_to_the_local_percy_server_for_responsive_snapshot_capture(self):
         mock_healthcheck(widths = { "config": [375, 1280], "mobile": [390]})
         mock_snapshot()
         dom_string = '<html><head></head><body>Snapshot Me</body></html>'
         self.driver.add_cookie({'name': 'foo', 'value': 'bar'})
-        expected_cookies = [{'name': 'foo', 'value': 'bar', 'path': '/', 'domain': 'localhost', 'secure': False, 'httpOnly': False, 'sameSite': 'None'}]
-        expected_dom_snapshot = [{ 'cookies': expected_cookies, 'html': dom_string, 'width': 1280 }, { 'cookies': expected_cookies, 'html': dom_string, 'width': 390 }, { 'cookies': expected_cookies, 'html': dom_string, 'width': 375 }]
+        expected_cookies = [{'name': 'foo', 'value': 'bar', 'path': '/', 'domain': 'localhost',
+            'secure': False, 'httpOnly': False, 'sameSite': 'None'}]
+        expected_dom_snapshot = [
+            { 'cookies': expected_cookies, 'html': dom_string, 'width': 1280 },
+            { 'cookies': expected_cookies, 'html': dom_string, 'width': 390 },
+            { 'cookies': expected_cookies, 'html': dom_string, 'width': 375 }
+        ]
 
         percy_snapshot(self.driver, 'Snapshot 1', responsiveSnapshotCapture = True)
-        percy_snapshot(self.driver, 'Snapshot 2', responsive_snapshot_capture = True, widths = [765])
+        percy_snapshot(self.driver, 'Snapshot 2', responsive_snapshot_capture=True, widths=[765])
         percy_snapshot(self.driver, 'Snapshot 3', responsive_snapshot_capture = True, width = 820)
 
         self.assertEqual(httpretty.last_request().path, '/percy/snapshot')
@@ -243,22 +252,33 @@ class TestPercySnapshot(unittest.TestCase):
 
         s2 = httpretty.latest_requests()[3].parsed_body
         self.assertEqual(s2['name'], 'Snapshot 2')
-        self.assertEqual(s2['dom_snapshot'], [{ 'cookies': expected_cookies, 'html': dom_string, 'width': 765 }, { 'html': dom_string, 'cookies': expected_cookies, 'width': 390 }])
+        self.assertEqual(s2['dom_snapshot'], [
+            { 'cookies': expected_cookies, 'html': dom_string, 'width': 765 },
+            { 'html': dom_string, 'cookies': expected_cookies, 'width': 390 }
+        ])
 
         s3 = httpretty.latest_requests()[4].parsed_body
         self.assertEqual(s3['name'], 'Snapshot 3')
-        self.assertEqual(s3['dom_snapshot'], [{ 'cookies': expected_cookies, 'html': dom_string, 'width': 820 }, { 'html': dom_string, 'cookies': expected_cookies, 'width': 390 }])
+        self.assertEqual(s3['dom_snapshot'], [
+            { 'cookies': expected_cookies, 'html': dom_string, 'width': 820 },
+            { 'html': dom_string, 'cookies': expected_cookies, 'width': 390 }
+        ])
 
     @patch('selenium.webdriver.Chrome')
-    def test_posts_snapshots_to_the_local_percy_server_for_responsive_snapshot_capture_with_cdp(self, MockChrome):
+    def test_posts_snapshots_to_the_local_percy_server_for_responsive_dom_chrome(self, MockChrome):
         driver = MockChrome.return_value
-        driver.execute_script.side_effect = ['', '', { 'html': 'some_dom' }, { 'html': 'some_dom_1' }]
+        driver.execute_script.side_effect = [
+            '', '', { 'html': 'some_dom' }, { 'html': 'some_dom_1' }
+        ]
         driver.get_cookies.return_value = ''
         driver.execute_cdp_cmd.return_value = ''
         driver.get_window_size.return_value = { 'height': 400, 'width': 800 }
         mock_healthcheck(widths = { "config": [375], "mobile": [390]})
         mock_snapshot()
-        expected_dom_snapshot = [{ 'cookies': '', 'html': 'some_dom', 'width': 600 }, { 'cookies': '', 'html': 'some_dom_1', 'width': 390 }]
+        expected_dom_snapshot = [
+            { 'cookies': '', 'html': 'some_dom', 'width': 600 },
+            { 'cookies': '', 'html': 'some_dom_1', 'width': 390 }
+        ]
 
         with patch.object(driver, 'current_url', 'http://localhost:8000/'):
             with patch.object(driver, 'capabilities', new={ 'browserName': 'chrome' }):
@@ -283,7 +303,8 @@ class TestPercySnapshot(unittest.TestCase):
         s1 = httpretty.latest_requests()[2].parsed_body
         self.assertEqual(s1['name'], 'Snapshot')
         self.assertEqual(s1['url'], 'http://localhost:8000/')
-        self.assertEqual(s1['dom_snapshot'], { 'html': '<html><head></head><body>Snapshot Me</body></html>', 'cookies': [] })
+        self.assertEqual(s1['dom_snapshot'], {
+            'html': '<html><head></head><body>Snapshot Me</body></html>', 'cookies': [] })
 
     def test_handles_snapshot_errors(self):
         mock_healthcheck(session_type="web")
@@ -294,7 +315,8 @@ class TestPercySnapshot(unittest.TestCase):
             percy_snapshot(self.driver, 'Snapshot 1')
 
             mock_print.assert_any_call(f'{LABEL} Could not take DOM snapshot "Snapshot 1"')
-        self.assertEqual(httpretty.latest_requests()[3].parsed_body, { 'message': f'{LABEL} Could not take DOM snapshot "Snapshot 1"', 'level': 'info' })
+        self.assertEqual(httpretty.latest_requests()[3].parsed_body, {
+            'message': f'{LABEL} Could not take DOM snapshot "Snapshot 1"', 'level': 'info' })
         self.assertEqual(len(httpretty.latest_requests()), 5)
 
     def test_raise_error_poa_token_with_snapshot(self):
@@ -461,8 +483,9 @@ class TestPercyScreenshot(unittest.TestCase):
             percy_screenshot(self.driver, 'Snapshot 1')
 
             mock_print.assert_any_call(f'{LABEL} Could not take Screenshot "Snapshot 1"')
-        
-        self.assertEqual(httpretty.latest_requests()[2].parsed_body, { 'message': f'{LABEL} Could not take Screenshot "Snapshot 1"', 'level': 'info' })
+
+        self.assertEqual(httpretty.latest_requests()[2].parsed_body, {
+            'message': f'{LABEL} Could not take Screenshot "Snapshot 1"', 'level': 'info' })
 
     def test_raise_error_web_token_with_screenshot(self):
         mock_healthcheck(session_type="web")


### PR DESCRIPTION
- Added option for `responsiveSnapshotCapture`. when this option is passed as true, we will capture dom in all widths returned by CLI.
- resize browser window using `set_window_size` for selenium 3 or non chrome browsers else using cdp to resize window. reason: in chrome we can only resize window upto 500px so to bypass this we are using cdp but running cdp command in selenium 3 is not supported.
- collect cookies using selenium driver.
- Send logs to cli via `/percy/log` endpoint