### PR TITLE
PoA support for selenium 4 without desired capibilites

### DIFF
--- a/percy/cache.py
+++ b/percy/cache.py
@@ -6,7 +6,6 @@ class Cache:
     TIMEOUT_KEY = 'last_access_time'
 
     # Caching Keys
-    session_capabilities = 'session_capabilities'
     capabilities = 'capabilities'
     command_executor_url = 'command_executor_url'
 

--- a/percy/driver_metadata.py
+++ b/percy/driver_metadata.py
@@ -32,7 +32,7 @@ class DriverMetaData:
         if session_caps is None:
             try:
                 session_caps = dict(self.driver.desired_capabilities)
-            except Exception as e:
+            except Exception:
                 session_caps = {}
             Cache.set_cache(self.session_id, Cache.session_capabilities, session_caps)
             return session_caps

--- a/percy/driver_metadata.py
+++ b/percy/driver_metadata.py
@@ -25,15 +25,3 @@ class DriverMetaData:
             Cache.set_cache(self.session_id, Cache.capabilities, caps)
             return caps
         return caps
-
-    @property
-    def session_capabilities(self):
-        session_caps = Cache.get_cache(self.session_id, Cache.session_capabilities)
-        if session_caps is None:
-            try:
-                session_caps = dict(self.driver.desired_capabilities)
-            except Exception:
-                session_caps = {}
-            Cache.set_cache(self.session_id, Cache.session_capabilities, session_caps)
-            return session_caps
-        return session_caps

--- a/percy/driver_metadata.py
+++ b/percy/driver_metadata.py
@@ -30,7 +30,10 @@ class DriverMetaData:
     def session_capabilities(self):
         session_caps = Cache.get_cache(self.session_id, Cache.session_capabilities)
         if session_caps is None:
-            session_caps = dict(self.driver.desired_capabilities)
+            try:
+                session_caps = dict(self.driver.desired_capabilities)
+            except Exception as e:
+                session_caps = {}
             Cache.set_cache(self.session_id, Cache.session_capabilities, session_caps)
             return session_caps
         return session_caps

--- a/percy/snapshot.py
+++ b/percy/snapshot.py
@@ -230,7 +230,6 @@ def percy_automate_screenshot(driver, name, options = None, **kwargs):
             'sessionId': metadata.session_id,
             'commandExecutorUrl': metadata.command_executor_url,
             'capabilities': metadata.capabilities,
-            'sessionCapabilites': metadata.session_capabilities,
             'snapshotName': name,
             'options': options
         }}, timeout=600)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -14,16 +14,9 @@ class TestCache(unittest.TestCase):
             'platform': 'windows',
             'browserVersion': '115.0.1'
           }
-        self.session_capabilities = {
-            'browser': 'chrome',
-            'platform': 'windows',
-            'browserVersion': '115.0.1',
-            'session_name': 'abc'
-          }
 
         self.cache.set_cache(self.session_id, Cache.command_executor_url, self.command_executor_url)
         self.cache.set_cache(self.session_id, Cache.capabilities, self.capabilities)
-        self.cache.set_cache(self.session_id, Cache.session_capabilities, self.session_capabilities)
 
     def test_set_cache(self):
         with self.assertRaises(Exception) as e:
@@ -39,8 +32,6 @@ class TestCache(unittest.TestCase):
                          self.command_executor_url)
         self.assertDictEqual(self.cache.CACHE[self.session_id][Cache.capabilities],
                              self.capabilities)
-        self.assertDictEqual(self.cache.CACHE[self.session_id][Cache.session_capabilities],
-                             self.session_capabilities)
 
     def test_get_cache_invalid_args(self):
         with self.assertRaises(Exception) as e:
@@ -57,8 +48,6 @@ class TestCache(unittest.TestCase):
         self.assertEqual(url, self.command_executor_url)
         caps = self.cache.get_cache(self.session_id, Cache.capabilities)
         self.assertDictEqual(caps, self.capabilities)
-        session_caps = self.cache.get_cache(self.session_id, Cache.session_capabilities)
-        self.assertDictEqual(session_caps, self.session_capabilities)
         mock_cleanup_cache.assert_called()
 
     @patch('percy.cache.Cache.CACHE_TIMEOUT', 1)

--- a/tests/test_driver_metadata.py
+++ b/tests/test_driver_metadata.py
@@ -49,22 +49,3 @@ class TestDriverMetadata(unittest.TestCase):
 
         self.mock_webdriver.capabilities = capabilities
         self.assertDictEqual(self.metadata.capabilities, capabilities)
-
-    @patch('percy.cache.Cache.CACHE', {})
-    def test_session_capabilities(self):
-        session_capabilities = {
-            'browser': 'chrome',
-            'platform': 'windows',
-            'browserVersion': '115.0.1',
-            'session_name': 'abc'
-          }
-
-        self.mock_webdriver.session_capabilities = session_capabilities
-        self.assertDictEqual(self.metadata.session_capabilities, session_capabilities)
-
-    @patch('percy.cache.Cache.CACHE', {})
-    def test_without_session_capabilities(self):
-        # this will raise error
-        self.mock_webdriver.desired_capabilities = 1
-
-        self.assertDictEqual(self.metadata.session_capabilities, {})

--- a/tests/test_driver_metadata.py
+++ b/tests/test_driver_metadata.py
@@ -61,3 +61,10 @@ class TestDriverMetadata(unittest.TestCase):
 
         self.mock_webdriver.session_capabilities = session_capabilities
         self.assertDictEqual(self.metadata.session_capabilities, session_capabilities)
+
+    @patch('percy.cache.Cache.CACHE', {})
+    def test_without_session_capabilities(self):
+        # this will raise error
+        self.mock_webdriver.desired_capabilities = 1
+
+        self.assertDictEqual(self.metadata.session_capabilities, {})

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -368,7 +368,6 @@ class TestPercyScreenshot(unittest.TestCase):
         driver = Mock(spec=mock_driver)
         driver.session_id = 'Dummy_session_id'
         driver.capabilities = { 'key': 'value' }
-        driver.desired_capabilities = { 'key': 'value' }
         driver.command_executor = Mock(spec=mock_connection)
         driver.command_executor._url = 'https://hub-cloud.browserstack.com/wd/hub' # pylint: disable=W0212
         return driver
@@ -481,7 +480,6 @@ class TestPercyScreenshot(unittest.TestCase):
         self.assertEqual(s1['sessionId'], driver.session_id)
         self.assertEqual(s1['commandExecutorUrl'], driver.command_executor._url) # pylint: disable=W0212
         self.assertEqual(s1['capabilities'], dict(driver.capabilities))
-        self.assertEqual(s1['sessionCapabilites'], dict(driver.desired_capabilities))
         self.assertRegex(s1['client_info'], r'percy-selenium-python/\d+')
         self.assertRegex(s1['environment_info'][0], r'selenium/\d+')
         self.assertRegex(s1['environment_info'][1], r'python/\d+')


### PR DESCRIPTION
- Fix for PoA with selenium version > 4.9 throwing error because desired capabilities property is deprecated from selenium