### PR TITLE
security: validate PERCY_CLI_API to loopback (PER-8913/8917/8918/8919, mitigates 8914)

### DIFF
--- a/percy/snapshot.py
+++ b/percy/snapshot.py
@@ -20,8 +20,33 @@ ENV_INFO = ['selenium/' + SELENIUM_VERSION, 'python/' + platform.python_version(
 def _get_bool_env(key):
     return os.environ.get(key, "").lower() == "true"
 
-# Maybe get the CLI API address from the environment
-PERCY_CLI_API = os.environ.get('PERCY_CLI_API') or 'http://localhost:5338'
+DEFAULT_PERCY_CLI_API = 'http://localhost:5338'
+_LOOPBACK_HOSTS = frozenset({'localhost', '127.0.0.1', '::1'})
+
+
+def _resolve_cli_api_address():
+    # The Percy CLI runs locally. PERCY_CLI_API is used as the base for every
+    # outbound call AND as the source of the @percy/dom script that is injected
+    # and executed in the browser, and the healthcheck response drives the
+    # session-type auth gate. An attacker-controlled value therefore enables
+    # SSRF, CLI-fetched-JS RCE, and an auth-gate bypass (CWE-918/CWE-94/CWE-306).
+    # Restrict it to loopback; allow a remote host only over HTTPS with an
+    # explicit opt-in, otherwise warn and fall back to the local default.
+    raw = os.environ.get('PERCY_CLI_API') or DEFAULT_PERCY_CLI_API
+    host = (urlparse(raw).hostname or '').lower()
+    if host in _LOOPBACK_HOSTS:
+        return raw
+    allow_remote = os.environ.get('PERCY_ALLOW_REMOTE_CLI_API', '').lower() in ('1', 'true', 'yes')
+    if allow_remote and urlparse(raw).scheme == 'https':
+        return raw
+    print(f"[percy] Ignoring non-loopback PERCY_CLI_API '{raw}'; falling back to "
+          f"{DEFAULT_PERCY_CLI_API}. To target a remote Percy CLI use an https:// URL "
+          "and set PERCY_ALLOW_REMOTE_CLI_API=true.")
+    return DEFAULT_PERCY_CLI_API
+
+
+# Maybe get the CLI API address from the environment (validated to loopback)
+PERCY_CLI_API = _resolve_cli_api_address()
 PERCY_DEBUG = os.environ.get('PERCY_LOGLEVEL') == 'debug'
 RESPONSIVE_CAPTURE_SLEEP_TIME = (
     os.environ.get('RESPONSIVE_CAPTURE_SLEEP_TIME') or

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -140,7 +140,11 @@ class TestResolveCliApiAddress(unittest.TestCase):
     def test_rejects_remote_host(self):
         self.assertEqual(_resolve_cli_api_address(), DEFAULT_PERCY_CLI_API)
 
-    @patch.dict(os.environ, {'PERCY_CLI_API': 'http://169.254.169.254/latest/meta-data'}, clear=True)
+    @patch.dict(
+        os.environ,
+        {'PERCY_CLI_API': 'http://169.254.169.254/latest/meta-data'},
+        clear=True,
+    )
     def test_rejects_link_local_ssrf_target(self):
         self.assertEqual(_resolve_cli_api_address(), DEFAULT_PERCY_CLI_API)
 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,4 +1,5 @@
 # pylint: disable=too-many-lines
+import os
 import unittest
 from unittest.mock import patch, Mock
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -18,6 +19,8 @@ from percy.snapshot import (
     _resolve_readiness_config,
     _wait_for_ready,
     get_serialized_dom,
+    _resolve_cli_api_address,
+    DEFAULT_PERCY_CLI_API,
 )
 
 from percy import percy_snapshot, percySnapshot, percy_screenshot
@@ -123,6 +126,38 @@ def mock_screenshot(fail=False, data=False):
             "data": data_object if data else None
         }),
         status=(500 if fail else 200))
+
+class TestResolveCliApiAddress(unittest.TestCase):
+    @patch.dict(os.environ, {}, clear=True)
+    def test_defaults_to_localhost(self):
+        self.assertEqual(_resolve_cli_api_address(), DEFAULT_PERCY_CLI_API)
+
+    @patch.dict(os.environ, {'PERCY_CLI_API': 'http://127.0.0.1:5338'}, clear=True)
+    def test_allows_loopback(self):
+        self.assertEqual(_resolve_cli_api_address(), 'http://127.0.0.1:5338')
+
+    @patch.dict(os.environ, {'PERCY_CLI_API': 'http://attacker.example/x'}, clear=True)
+    def test_rejects_remote_host(self):
+        self.assertEqual(_resolve_cli_api_address(), DEFAULT_PERCY_CLI_API)
+
+    @patch.dict(os.environ, {'PERCY_CLI_API': 'http://169.254.169.254/latest/meta-data'}, clear=True)
+    def test_rejects_link_local_ssrf_target(self):
+        self.assertEqual(_resolve_cli_api_address(), DEFAULT_PERCY_CLI_API)
+
+    @patch.dict(os.environ, {
+        'PERCY_CLI_API': 'https://percy-cli.internal:5338',
+        'PERCY_ALLOW_REMOTE_CLI_API': 'true'
+    }, clear=True)
+    def test_allows_remote_https_with_opt_in(self):
+        self.assertEqual(_resolve_cli_api_address(), 'https://percy-cli.internal:5338')
+
+    @patch.dict(os.environ, {
+        'PERCY_CLI_API': 'http://percy-cli.internal:5338',
+        'PERCY_ALLOW_REMOTE_CLI_API': 'true'
+    }, clear=True)
+    def test_remote_opt_in_still_requires_https(self):
+        self.assertEqual(_resolve_cli_api_address(), DEFAULT_PERCY_CLI_API)
+
 
 # pylint: disable=too-many-public-methods
 class TestPercySnapshot(unittest.TestCase):


### PR DESCRIPTION
## Summary
Five **High** runtime findings in `@percy/selenium-python` (deadline 2026-06-22) share one root: an unvalidated `PERCY_CLI_API`.

| Ticket | CWE | Finding |
|--------|-----|---------|
| [PER-8919](https://browserstack.atlassian.net/browse/PER-8919) | CWE-918 | SSRF via env-var-controlled Percy CLI base URL |
| [PER-8913](https://browserstack.atlassian.net/browse/PER-8913) | CWE-306 | Session-type auth gate bypassed via attacker-controlled CLI URL |
| [PER-8917](https://browserstack.atlassian.net/browse/PER-8917) | CWE-494 | Externally-fetched JS injected into browser without integrity verification |
| [PER-8918](https://browserstack.atlassian.net/browse/PER-8918) | CWE-79 | Unverified script injected into cross-origin iframe via `execute_script` |
| [PER-8914](https://browserstack.atlassian.net/browse/PER-8914) | CWE-79 | LRU-cached poisoned DOM script persists for the process lifetime *(mitigated)* |

## Root cause + fix
`PERCY_CLI_API` was read from the env with no validation and used as (a) the base for all outbound calls, (b) the source of the `@percy/dom` script injected/executed in the page (and into cross-origin iframes), and (c) the origin of the healthcheck that drives the session-type auth gate. A hostile value is therefore SSRF + CLI-fetched-JS RCE + auth-gate bypass.

Added `_resolve_cli_api_address()`: **loopback-only** (`localhost`/`127.0.0.1`/`::1`) by default; a remote host is allowed only over **HTTPS** with an explicit `PERCY_ALLOW_REMOTE_CLI_API` opt-in; otherwise it warns and falls back to `http://localhost:5338`.

Because the injected DOM script and the cached script can now only come from a loopback CLI, this single fix closes 8919/8913/8917/8918 and mitigates 8914 (the lru-cached script is now trusted-source).

## Verification
- Validator logic unit-verified (loopback allow; remote + `169.254.169.254` reject; https opt-in). Added a `TestResolveCliApiAddress` unit class.
- Option payloads are already JSON-encoded via `json.dumps`, so they aren't string-interpolated into `execute_script`.

Closes PER-8913, PER-8917, PER-8918, PER-8919; mitigates PER-8914. (The 06-22 chain tickets for this repo close once their linked components are resolved.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PER-8919]: https://browserstack.atlassian.net/browse/PER-8919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PER-8913]: https://browserstack.atlassian.net/browse/PER-8913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PER-8917]: https://browserstack.atlassian.net/browse/PER-8917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PER-8918]: https://browserstack.atlassian.net/browse/PER-8918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PER-8914]: https://browserstack.atlassian.net/browse/PER-8914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ