### PR TITLE
release v2.2.1-beta.1

### DIFF
--- a/percy/version.py
+++ b/percy/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.2.1-beta.0"
+__version__ = "2.2.1-beta.1"


### PR DESCRIPTION
Bumps the SDK to the next beta (`2.2.1-beta.0` → `2.2.1-beta.1`) for a beta release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)