### PR TITLE
ci: expose built percy on PATH in CLI-branch injection (PER-9772)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,8 +57,15 @@ jobs:
           yarn
           yarn build
           yarn global:link
-          cd ${{ github.workspace }} 
-          yarn remove @percy/cli && yarn link `echo $PERCY_PACKAGES`
-          npx percy --version
+          # Expose the freshly built `percy` on PATH. yarn link symlinks the
+          # package but not its bin, so `npx percy` would miss it and download
+          # the unrelated public `percy`. Link is best-effort (non-JS repos have
+          # no node project to link into); PATH is what makes percy resolvable.
+          echo "$(yarn global bin)" >> "$GITHUB_PATH"
+          export PATH="$(yarn global bin):$PATH"
+          cd ${{ github.workspace }}
+          yarn remove @percy/cli >/dev/null 2>&1 || true
+          yarn link `echo $PERCY_PACKAGES` >/dev/null 2>&1 || true
+          percy --version
        
       - run: make coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,9 +48,11 @@ jobs:
           restore-keys: v1/${{ runner.os }}/node-${{ matrix.node }}/
       - name: Set up @percy/cli from git
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          BRANCH: ${{ github.event.inputs.branch }}
         run: |
           cd /tmp
-          git clone --branch ${{ github.event.inputs.branch }} --depth 1 https://github.com/percy/cli
+          git clone --branch "$BRANCH" --depth 1 https://github.com/percy/cli
           cd cli
           PERCY_PACKAGES=`find packages -mindepth 1 -maxdepth 1 -type d | sed -e 's/packages/@percy/g' | tr '\n' ' '`
           git log -1


### PR DESCRIPTION
Fixes CLI-branch SDK regression for this repo: `npx percy` couldn't resolve the yarn-linked `@percy/cli` (link symlinks the package, not its bin) → it downloaded `percy@5.0.0` and the inject step failed. Now we add the built CLI's bin to PATH and verify with `percy --version`; the yarn link is best-effort so non-JS repos don't abort on a missing lockfile. Part of PER-9772. 🤖 Generated with [Claude Code](https://claude.com/claude-code)