### PR TITLE
chore: release 2.2.1-beta.2

### DIFF
--- a/percy/version.py
+++ b/percy/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.2.1-beta.1"
+__version__ = "2.2.1-beta.2"


### PR DESCRIPTION
Bumps `percy/version.py` to `2.2.1-beta.2` so the config-merge regression fix (#250) can publish. `v2.2.1-beta.1` already shipped to PyPI with the broken merge and PyPI versions are immutable, so the fix goes out as a new pre-release beta.

Follows #250 (fix: merge .percy.yml config into serialize options).